### PR TITLE
Add macos to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: 11
+          distribution: 'temurin'
+          cache: 'maven'
       - name: Build with Maven
         run: mvn -e -B test


### PR DESCRIPTION
This adds macOS to the test matrix, so that we can catch any regressions (e.g. building without TLS #10), since that build is not scripted.