### PR TITLE
Update paths and build instructions for macOS builds

### DIFF
--- a/src/main/java/redis/embedded/RedisExecProvider.java
+++ b/src/main/java/redis/embedded/RedisExecProvider.java
@@ -30,7 +30,7 @@ public class RedisExecProvider {
         executables.put(OsArchitecture.UNIX_x86_64, "redis-server-" + redisVersion + "-linux-amd64");
         executables.put(OsArchitecture.UNIX_arm64, "redis-server-" + redisVersion + "-linux-arm64");
 
-        executables.put(OsArchitecture.MAC_OS_X_x86_64, "redis-server-" + redisVersion + "-darwin-x86_64");
+        executables.put(OsArchitecture.MAC_OS_X_x86_64, "redis-server-" + redisVersion + "-darwin-amd64");
         executables.put(OsArchitecture.MAC_OS_X_arm64, "redis-server-" + redisVersion + "-darwin-arm64");
     }
 

--- a/src/test/java/redis/embedded/RedisServerTest.java
+++ b/src/test/java/redis/embedded/RedisServerTest.java
@@ -100,7 +100,7 @@ public class RedisServerTest {
                 .override(OS.UNIX, Architecture.x86, Resources.getResource("redis-server-" + RedisExecProvider.redisVersion + "-linux-386").getFile())
                 .override(OS.UNIX, Architecture.x86_64, Resources.getResource("redis-server-" + RedisExecProvider.redisVersion + "-linux-amd64").getFile())
                 .override(OS.UNIX, Architecture.arm64, Resources.getResource("redis-server-" + RedisExecProvider.redisVersion + "-linux-arm64").getFile())
-                .override(OS.MAC_OS_X, Architecture.x86_64, Resources.getResource("redis-server-" + RedisExecProvider.redisVersion + "-darwin-x86_64").getFile())
+                .override(OS.MAC_OS_X, Architecture.x86_64, Resources.getResource("redis-server-" + RedisExecProvider.redisVersion + "-darwin-amd64").getFile())
                 .override(OS.MAC_OS_X, Architecture.arm64, Resources.getResource("redis-server-" + RedisExecProvider.redisVersion + "-darwin-arm64").getFile());
 
         redisServer = new RedisServerBuilder()


### PR DESCRIPTION
This updates our build instructions for creating Redis binaries for macOS. The two big things are:

1. Explicitly document that this assumes two parallel Homebrew installations (at least if the intent is to build both macOS binaries in a single shot); this has always been the case, but we can be clearer about it!
2. Update expected openssl paths; somewhere along the line, Homebrew changed where openssl 1.1 gets installed to avoid conflicts with openssl 3.