### PR TITLE
Update to the latest Nexus staging plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.8</version>
+                <version>1.6.13</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>


### PR DESCRIPTION
I just released 0.8.3 and bumped into https://issues.sonatype.org/browse/NEXUS-27902 (again). Allegedly, this is fixed in the latest Nexus staging plugin, so let's update it for the next time we do a release.