### PR TITLE
upgrade vulnerable Guava and JUnit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>29.0-jre</version>
+            <version>31.1-jre</version>
         </dependency>
 
         <dependency>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
The currently used version of Guava is affected by CVE-2020-8908 (see also https://github.com/google/guava/issues/4011).
The currently used version of JUnit is affected by CVE-2020-15250.

This PR upgrades both dependencies to the latest available versions, which are not affected by any CVE.