### PR TITLE
Update to `commons-io` 2.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.7</version>
+            <version>2.17.0</version>
         </dependency>
 
         <!-- TEST DEPENDENCIES -->


### PR DESCRIPTION
This updates our dependency on `commons-io` to 2.17.0, the latest version available upstream.